### PR TITLE
Use attribute names in dashCase format if available

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -90,8 +90,9 @@ const mapPropsData = (data: StencilJsonDocsProp[]): ArgTypes => {
     data &&
     data.reduce((acc, item) => {
       const { control, options } = mapPropTypeToControl(item);
+      const key = item.attr || item.name;
 
-      acc[item.name] = {
+      acc[key] = {
         name: item.attr || item.name,
         description: item.docs,
         type: { required: item.required },
@@ -103,7 +104,7 @@ const mapPropsData = (data: StencilJsonDocsProp[]): ArgTypes => {
         },
       };
 
-      if (options !== null) acc[item.name].options = options;
+      if (options !== null) acc[key].options = options;
 
       return acc;
     }, {} as ArgTypes)


### PR DESCRIPTION
This PR fixes the issue which is mentioned in #8. If an item.attr (in dashCase format) is available it is used as a key in the argTable. By that, attributes will we set in dashCase in Storybook. Right now they are set in camelCase. Please check.

Best
Michael