### PR TITLE
Replace config with previewAnnotations

### DIFF
--- a/src/preset.ts
+++ b/src/preset.ts
@@ -1,5 +1,5 @@
-// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unused-vars
-export function config(entry: any[] = [], _: any = {}): any[] {
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export function previewAnnotations(entry: any[] = [], _: any = {}): StorybookConfig['previewAnnotations'] {
   // @ts-ignore
   return [require.resolve(`./config`), ...entry];
 }


### PR DESCRIPTION
In the current Storybook 7 version, I'm getting the following warning:

```
WARN You (or an addon) are using the 'config' preset field. This has been replaced by 'previewAnnotations' and will be removed in 8.0
```

I didn't test the change.

[Docs source for Storybook previewAnnotations](https://storybook.js.org/docs/api/main-config-preview-annotations)